### PR TITLE
"import android.content.Context;" added

### DIFF
--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/app/src/main/java/com/example/android/datafrominternet/MainActivity.java
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/app/src/main/java/com/example/android/datafrominternet/MainActivity.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.EditText;
 import android.widget.TextView;
+import android.content.Context;
 
 public class MainActivity extends AppCompatActivity {
 


### PR DESCRIPTION
In the video lesson we have to use Content, but in the entire video no one import it. Should be imported by default, so the video is correct.
Sorry for my bad English but I'm not native