### PR TITLE
T10.01 Renaming executeTaskForTag → executeTask

### DIFF
--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/src/main/java/com/example/android/background/sync/WaterReminderIntentService.java
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/src/main/java/com/example/android/background/sync/WaterReminderIntentService.java
@@ -20,4 +20,4 @@
 
 //  TODO (11) Override onHandleIntent
 //      TODO (12) Get the action from the Intent that started this Service
-//      TODO (13) Call ReminderTasks.executeTaskForTag and pass in the action to be performed
+//      TODO (13) Call ReminderTasks.executeTask and pass in the action to be performed


### PR DESCRIPTION
Method `ReminderTasks.executeTaskForTag` doesn't exist.