### PR TITLE
Update all gradle files to latest Android Studio 3.0

### DIFF
--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,8 +20,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 
     // TODO (7) Remove the ConstraintLayout dependency as we aren't using it for these simple projects
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 }

--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,8 +20,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 
     // TODO (32) Remove the ConstraintLayout dependency as we aren't using it for these simple projects
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 
     // COMPLETED (32) Remove the ConstraintLayout dependency as we aren't using it for these simple projects
 }

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 
     // TODO (1) Add RecyclerView dependency
 }

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,8 +20,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // COMPLETED (1) Add RecyclerView dependency
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }
 

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -20,5 +20,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // TODO (1) Add the gradle dependency for the support preference fragment
 }

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,7 +19,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // COMPLETED (1) Add the gradle dependency for the support preference fragment
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.06-Exercise-AddTwoMoreCheckboxes/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:preference-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:preference-v7:27.0.0'
 }

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/app/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/app/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/app/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/app/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/app/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/app/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/app/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/app/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
     testCompile 'junit:junit:4.12'
 }

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile project(":droidtermsprovider")
 }

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/droidtermsprovider/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 14
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile project(":droidtermsprovider")
 }

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/droidtermsprovider/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 14
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile project(":droidtermsprovider")
 }

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 14
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile project(":droidtermsprovider")
 }

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 14
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile project(":droidtermsprovider")
 }

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/droidtermsprovider/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 14
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile project(":droidtermsprovider")
 }

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/droidtermsprovider/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         minSdkVersion 14
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15
@@ -21,20 +21,20 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 
     //add Recycler view dependencies; must match SDK version
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 
     //FAB dependencies
-    compile 'com.android.support:design:25.1.0'
+    compile 'com.android.support:design:27.0.0'
 
     //Testing
     // Instrumentation dependencies use androidTestCompile
     // (as opposed to testCompile for local unit tests run in the JVM)
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.1.0'
+    androidTestCompile 'com.android.support:support-annotations:27.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,5 +19,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 }

--- a/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // TODO (1) Add gradle dependency for Firebase Job Dispatcher
 }

--- a/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,7 +19,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // COMPLETED (1) Add gradle dependency for Firebase Job Dispatcher
     compile 'com.firebase:firebase-jobdispatcher:0.5.2'
 }

--- a/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile 'com.firebase:firebase-jobdispatcher:0.5.2'
 }

--- a/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile 'com.firebase:firebase-jobdispatcher:0.5.2'
 }

--- a/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile 'com.firebase:firebase-jobdispatcher:0.5.2'
 }

--- a/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:26.0.1'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     compile 'com.firebase:firebase-jobdispatcher:0.5.2'
 }

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
         maven {
             url "https://maven.google.com"
         }

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -22,6 +22,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // TODO (1) Add the compile dependency for the constraint layout support library
 }

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
     // COMPLETED (1) Add the compile dependency for the constraint layout support library
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 }

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
     // TODO (1) Enable Data Binding in your application
 }

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -24,6 +24,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 }

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -23,6 +23,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 }

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"
-        minSdkVersion 10
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -23,6 +23,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta4'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.0-beta3'
 }

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.0'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16
@@ -21,6 +21,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     // for RecyclerView
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
+    compile 'com.android.support:recyclerview-v7:27.0.0'
 }

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +20,7 @@ allprojects {
     }
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Opening each project with latest stable Android Studio 3.0 is always suggesting to update:
* Gradle version to 4.1
* Android plugin for Gradle
* SDK versions
* Android (support) versions

This would resolve an issue other students had, like #220.

@dnbit, @ceruleanotter could you please review this?