### PR TITLE
T10.06: Show the pink icon when charging on older devices

### DIFF
--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
@@ -9,6 +9,9 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        // COMPLETED Set vectorDrawables.useSupportLibrary = true to support vector drawable
+        // on devices running platform versions lower than Android 5.0
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/src/main/res/layout/activity_main.xml
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- COMPLETED: Add xmlns:app="http://schemas.android.com/apk/res-auto" to use vector support libraries -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/activity_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -21,6 +23,7 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
+        <!-- COMPLETED: Change android:src to app:srcCompat -->
         <ImageButton
             android:id="@+id/ib_water_increment"
             android:layout_width="match_parent"
@@ -30,7 +33,7 @@
             android:onClick="incrementWater"
             android:padding="8dp"
             android:scaleType="fitCenter"
-            android:src="@drawable/ic_local_drink_grey_120px" />
+            app:srcCompat="@drawable/ic_local_drink_grey_120px" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -66,12 +69,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 
+        <!-- COMPLETED: Change android:src to app:srcCompat -->
         <ImageView
             android:id="@+id/iv_power_increment"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/charging_plug_content_desc"
-            android:src="@drawable/ic_power_grey_80px" />
+            app:srcCompat="@drawable/ic_power_grey_80px" />
 
         <TextView
             android:id="@+id/tv_charging_reminder_count"


### PR DESCRIPTION
There is a problem in T10.05 and T10.06-Solution. On older devices like my mobile phone running Android 4.4.4 vector drawables do not work properly and color of icon does not change  when you plug and unplug the device. I provide this pull request with little changes to support for vector drawables on devices running platform versions lower than Android 5.0.