### PR TITLE
Update build.gradle

### DIFF
--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {


### PR DESCRIPTION
Adding 

vectorDrawables.useSupportLibrary = true

to the default config in the app's gradle resolves not gradle not syncing with using some of the resources in this exercise in updated versions of gradle and android. This needs to be applied throughout each part of exercise 10.