### PR TITLE
T05b.03: Update MainActivity.java

### DIFF
--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/src/main/java/com/example/android/asynctaskloader/MainActivity.java
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/src/main/java/com/example/android/asynctaskloader/MainActivity.java
@@ -177,12 +177,6 @@ public class MainActivity extends AppCompatActivity implements
                     return;
                 }
 
-                /*
-                 * When we initially begin loading in the background, we want to display the
-                 * loading indicator to the user
-                 */
-                mLoadingIndicator.setVisibility(View.VISIBLE);
-
                 // COMPLETED (2) If mGithubJson is not null, deliver that result. Otherwise, force a load
                 /*
                  * If we already have cached results, just deliver them now. If we don't have any
@@ -191,6 +185,11 @@ public class MainActivity extends AppCompatActivity implements
                 if (mGithubJson != null) {
                     deliverResult(mGithubJson);
                 } else {
+                    /*
+                    * When we initially begin loading in the background, we want to display the
+                    * loading indicator to the user
+                    */
+                    mLoadingIndicator.setVisibility(View.VISIBLE);
                     forceLoad();
                 }
             }


### PR DESCRIPTION
When we navigate between apps, the mLoadingIndicator is always visible.
The mLoadingIndicator becomes invisible in method onLoadFinished.
This is because when we navigate between apps, onLoadFinished method is not called.
We have 2 approach of fixing this.
1. Show mLoadingIndicator immediately before calling forceload function.
2. Hide mLoadingIndicator in the deliverResult overriden function.
The 1st method is applied in this commit.