### PR TITLE
T02.01 - Move app schema deletion after deleting textview.

### DIFF
--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/app/src/main/res/layout/activity_main.xml
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/app/src/main/res/layout/activity_main.xml
@@ -19,7 +19,8 @@
 <!--TODO (2) Make the orientation vertical-->
 <!--TODO (3) Give left, right, and top padding of 16dp-->
 <!--TODO (4) Remove the line that declares the id, we don't need it-->
-<!--TODO (5) Remove the xmlns:app declaration, we don't need that anymore-->
+
+<!--TODO (6) Remove the xmlns:app declaration, we don't need that anymore-->
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -27,7 +28,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!--TODO (6) Delete this TextView-->
+    <!--TODO (5) Delete this TextView-->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/app/src/main/res/layout/activity_main.xml
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/app/src/main/res/layout/activity_main.xml
@@ -18,7 +18,7 @@
 <!--COMPLETED (2) Make the orientation vertical-->
 <!--COMPLETED (3) Give left, right, and top padding of 16dp-->
 <!--COMPLETED (4) Remove the line that declares the id, we don't need it-->
-<!--COMPLETED (5) Remove the xmlns:app declaration, we don't need that anymore-->
+<!--COMPLETED (6) Remove the xmlns:app declaration, we don't need that anymore-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -29,7 +29,7 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="com.example.android.datafrominternet.MainActivity">
 
-    <!--COMPLETED (6) Delete this TextView-->
+    <!--COMPLETED (5) Delete this TextView-->
     <!--COMPLETED (7) Add an EditText-->
     <!--COMPLETED (8) Give the EditText an id of @+id/et_search_box-->
     <!--COMPLETED (9) Set the text size to 22sp-->


### PR DESCRIPTION
When you delete the app namespace schema reference ("app:xmlns") before deleting the text view, android studio will tell you that your xml document is invalid because the "app" is still referenced by the text view.

This PR will reorder the TODO to delete the text view first and then delete the schema reference.