### PR TITLE
Upgrade lessons to Android Gradle plugin 3.0.1 and Gradle 4.1

### DIFF
--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"

--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 12:41:00 PST 2017
+#Tue Feb 06 04:14:57 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 12:41:00 PST 2017
+#Thu Jan 25 06:20:44 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.02-Exercise-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 12:41:00 PST 2017
+#Tue Feb 06 05:55:57 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.02-Solution-DisplayToyList/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 12:41:00 PST 2017
+#Thu Jan 25 06:24:50 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.03-Exercise-AddScrolling/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 12:41:00 PST 2017
+#Tue Feb 06 06:23:51 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.android.example.favoritetoys"

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson01-Favorite-Toys/T01.03-Solution-AddScrolling/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 12:41:00 PST 2017
+#Fri Jan 26 01:58:52 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Exercise-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Tue Feb 06 06:32:25 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.01-Solution-CreateLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Fri Jan 26 03:42:37 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Exercise-AddMenu/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Tue Feb 06 07:07:56 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.02-Solution-AddMenu/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Fri Jan 26 06:26:46 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Exercise-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Tue Feb 06 07:17:13 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.03-Solution-DisplayUrl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Fri Jan 26 06:28:51 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Exercise-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Tue Feb 06 07:31:01 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.04-Solution-ConnectingToTheInternet/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Fri Jan 26 06:33:38 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Exercise-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Tue Feb 06 07:41:00 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.05-Solution-CreateAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Fri Jan 26 06:35:10 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Exercise-AddPolish/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Tue Feb 06 07:56:45 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/app/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.datafrominternet"

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/build.gradle
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson02-GitHub-Repo-Search/T02.06-Solution-AddPolish/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:35:09 PST 2017
+#Fri Jan 26 06:36:55 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.01-Exercise-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 08:29:01 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.01-Solution-RecyclerViewLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 06:38:37 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.02-Exercise-ViewHolder/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 08:49:27 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.02-Solution-ViewHolder/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 06:40:26 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.03-Exercise-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 09:06:06 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.03-Solution-RecyclerViewAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 23:16:43 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.04-Exercise-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 10:25:41 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.04-Solution-WiringUpRecyclerView/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 23:20:12 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.05-Exercise-GoingGreen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 10:31:44 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.05-Solution-GoingGreen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 23:23:30 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.06-Exercise-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 10:48:44 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.06-Solution-RefreshMenuButton/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 23:31:15 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.07-Exercise-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Tue Feb 06 11:18:05 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/app/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.recyclerview"

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/build.gradle
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson03-Green-Recycler-View/T03.07-Solution-RecyclerViewClickHandling/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 10:56:36 PST 2017
+#Fri Jan 26 23:34:24 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Exercise-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:27:29 PST 2017
+#Tue Feb 06 13:37:45 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.01-Solution-AddNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:27:29 PST 2017
+#Fri Jan 26 23:36:29 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Exercise-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:27:29 PST 2017
+#Tue Feb 06 14:05:02 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.02-Solution-StartNewActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:27:29 PST 2017
+#Fri Jan 26 23:39:47 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/app/src/main/java/com/example/android/explicitintent/ChildActivity.java
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/app/src/main/java/com/example/android/explicitintent/ChildActivity.java
@@ -15,6 +15,7 @@
  */
 package com.example.android.explicitintent;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.TextView;

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Exercise-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:27:29 PST 2017
+#Tue Feb 06 14:10:21 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/app/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.explicitintent"

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/build.gradle
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04a-Starting-New-Activities/T04a.03-Solution-PassingDataBetweenActivities/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:27:29 PST 2017
+#Fri Jan 26 23:44:15 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Exercise-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:33:30 PST 2017
+#Tue Feb 06 14:19:32 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.01-Solution-OpenWebpage/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:33:30 PST 2017
+#Fri Jan 26 23:46:39 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Exercise-OpenMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:33:30 PST 2017
+#Tue Feb 06 14:27:56 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.02-Solution-OpenMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:33:30 PST 2017
+#Sat Jan 27 00:12:20 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Exercise-ShareText/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:33:30 PST 2017
+#Tue Feb 06 14:40:10 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/app/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.implicitintents"

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/build.gradle
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson04b-Webpages-Maps-and-Sharing/T04b.03-Solution-ShareText/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:33:30 PST 2017
+#Sat Jan 27 00:17:04 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Exercise-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:40:50 PST 2017
+#Tue Feb 06 15:35:35 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.01-Solution-LogLifecycle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:40:50 PST 2017
+#Sat Jan 27 03:43:59 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Exercise-PersistData/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:40:50 PST 2017
+#Tue Feb 06 15:42:51 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.02-Solution-PersistData/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:40:50 PST 2017
+#Sat Jan 27 03:46:55 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Exercise-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:40:50 PST 2017
+#Tue Feb 06 15:49:35 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/app/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.lifecycle"

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/build.gradle
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05a-Android-Lifecycle/T05a.03-Solution-FixLifecycleDisplayBug/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:40:50 PST 2017
+#Sat Jan 27 03:48:02 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Exercise-SaveResults/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:54:14 PST 2017
+#Tue Feb 06 15:58:18 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.01-Solution-SaveResults/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:54:14 PST 2017
+#Sun Jan 28 04:34:09 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Exercise-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:54:14 PST 2017
+#Tue Feb 06 16:13:31 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.02-Solution-AddAsyncTaskLoader/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:54:14 PST 2017
+#Sun Jan 28 04:36:36 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Exercise-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:54:14 PST 2017
+#Tue Feb 06 17:19:46 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.example.android.asynctaskloader"

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/build.gradle
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 10:54:14 PST 2017
+#Sun Jan 28 04:37:52 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.01-Exercise-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Feb 06 22:15:56 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.01-Solution-SetupTheActivity/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Sun Jan 28 04:42:40 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.02-Exercise-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Wed Feb 07 03:35:20 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.02-Solution-MakeAPreferenceFragment/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Sun Jan 28 04:45:01 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.03-Exercise-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Wed Feb 07 04:31:10 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.03-Solution-ReadingFromSharedPreferences/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 04:35:32 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.04-Exercise-UseResources/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Wed Feb 07 11:25:28 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.04-Solution-UseResources/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 07:27:27 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.05-Exercise-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Thu Feb 08 00:51:04 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.05-Solution-PreferenceChangeListener/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 07:30:30 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.06-Solution-AddTwoMoreCheckboxes/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 08:21:18 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.07-Exercise-ListPreference/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Thu Feb 08 01:46:14 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.07-Solution-ListPreference/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 08:23:54 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.08-Exercise-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Thu Feb 08 06:14:09 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.08-Solution-PreferenceSummary/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 08:37:39 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.09-Exercise-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Thu Feb 08 07:23:11 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.09-Solution-EditTextPreference/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 08:45:33 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.10-Exercise-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Thu Feb 08 09:53:21 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/app/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "android.example.com.visualizerpreferences"
         minSdkVersion 10

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/build.gradle
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson06-Visualizer-Preferences/T06.10-Solution-EditTextPreferenceConstraints/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:33:58 PST 2017
+#Tue Jan 30 08:49:33 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/app/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 04:20:34 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/app/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/build.gradle
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.01-Solution-CreateAContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.01-Solution-CreateAContract/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Jan 30 20:52:40 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/app/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.02-Exercise-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 04:40:02 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/app/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/build.gradle
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.02-Solution-CreateTheDatabase/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 04:54:50 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/app/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.03-Exercise-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 05:07:11 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/app/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/build.gradle
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.03-Solution-GetAllTheData/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Wed Jan 31 02:35:48 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/app/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.04-Exercise-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 05:27:31 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/app/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/build.gradle
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.04-Solution-UpdateTheAdapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Wed Jan 31 02:39:36 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.05-Exercise-AddGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.05-Exercise-AddGuests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 05:37:35 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.05-Solution-AddGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.05-Solution-AddGuests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Wed Jan 31 02:44:58 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.06-Exercise-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Tue Feb 13 05:56:30 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/app/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.waitlist"
         minSdkVersion 15

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/build.gradle
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson07-Waitlist/T07.06-Solution-RemoveGuests/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 17:49:53 PST 2017
+#Wed Jan 31 02:47:12 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/droidtermsprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.01-Exercise-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 14:00:37 PST 2017
+#Tue Feb 13 06:30:36 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/droidtermsprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.01-Solution-AddTheContentProviderPermission/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 14:00:37 PST 2017
+#Wed Jan 31 02:54:42 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.02-Exercise-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 14:00:37 PST 2017
+#Tue Feb 13 15:32:57 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/droidtermsprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.02-Solution-AddAsyncTaskToRetrieveCursor/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 14:00:37 PST 2017
+#Wed Jan 31 03:00:35 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/droidtermsprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.03-Exercise-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 14:00:37 PST 2017
+#Tue Feb 13 16:04:17 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/app/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.udacity.example.quizexample"

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/droidtermsprovider/build.gradle
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/droidtermsprovider/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson08-Quiz-Example/T08.03-Solution-FinishQuizExample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 06 14:00:37 PST 2017
+#Wed Jan 31 03:12:23 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.01-Exercise-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Tue Feb 13 17:19:32 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/build.gradle
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.01-Solution-SetupContentProvider/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.02-Exercise-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Tue Feb 13 18:42:03 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/build.gradle
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.02-Solution-AddURIsToContract/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.03-Exercise-UriMatcher/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Feb 14 01:24:13 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/build.gradle
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.03-Solution-UriMatcher/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Feb 14 07:08:02 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.04-Exercise-Insert/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.04-Exercise-Insert/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Feb 14 01:28:33 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/build.gradle
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.04-Solution-Insert/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.04-Solution-Insert/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Jan 31 04:27:41 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.05-Exercise-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Feb 14 01:30:26 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/build.gradle
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.05-Solution-QueryAllTasks/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Jan 31 04:31:43 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.06-Exercise-Delete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.06-Exercise-Delete/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Feb 14 01:32:15 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/build.gradle
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.06-Solution-Delete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.06-Solution-Delete/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Jan 31 04:36:37 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.07-Exercise-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Feb 14 01:42:23 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/app/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.todolist"
         minSdkVersion 15

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/build.gradle
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson09-ToDo-List/T09.07-Solution-SwipeToDelete/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:01:36 PST 2017
+#Wed Jan 31 06:14:01 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.01-Exercise-IntentServices/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 01:44:25 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:11:44 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.02-Exercise-CreateNotification/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 19:58:08 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:14:23 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.03-Exercise-NotificationActions/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:34:42 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:17:56 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.04-Exercise-PeriodicSyncWithJobDispatcher/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:41:55 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:20:43 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.05-Exercise-ChargingBroadcastReceiver/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:59:27 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 02:52:30 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.06-Exercise-StickyBroadcastForCharging/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 03:02:15 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.example.android.background"
         minSdkVersion 14

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 25 13:19:01 AEST 2017
+#Wed Feb 14 03:00:59 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.01-Exercise-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:46:30 PST 2017
+#Wed Feb 14 03:09:10 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:46:30 PST 2017
+#Wed Feb 14 03:04:06 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.02-Exercise-DataBinding/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:46:30 PST 2017
+#Wed Feb 14 03:12:26 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:46:30 PST 2017
+#Wed Feb 14 03:10:51 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.03-Exercise-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:46:30 PST 2017
+#Wed Feb 14 03:14:34 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.example.android.boardingpass"

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 11:46:30 PST 2017
+#Wed Feb 14 03:13:37 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.01-Exercise-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:17:00 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/build.gradle
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.01-Solution-ColorsAndFonts/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:15:56 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.02-Exercise-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:19:05 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/build.gradle
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.02-Solution-CreateNewStyles/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:18:03 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.03-Exercise-TabletLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:21:09 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/build.gradle
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.03-Solution-TabletLayout/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:20:02 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.04-Exercise-TouchSelector/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:24:19 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/app/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.example.android.visualpolish"
         minSdkVersion 16

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/build.gradle
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/gradle/wrapper/gradle-wrapper.properties
+++ b/Lesson12-Visual-Polish/T12.04-Solution-TouchSelector/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jan 13 12:15:50 PST 2017
+#Wed Feb 14 03:22:03 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
“To take advantage of all the latest features (such as Instant Run),
improvements, and security fixes”

“Warning:The specified Android SDK Build Tools version (25.0.2) is
ignored, as it is below the minimum supported version (26.0.2) for
Android Gradle Plugin 3.0.1.
Android SDK Build Tools 26.0.2 will be used.
To suppress this warning, remove "buildToolsVersion '25.0.2'" from your
build.gradle file, as each version of the Android Gradle Plugin now has
a default version of the build tools.”

(Android Studio 3.0.1)