### PR TITLE
T10 - Use support library for vector drawables

### DIFF
--- a/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.01-Solution-IntentServices/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.02-Solution-CreateNotification/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.03-Solution-NotificationActions/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.04-Solution-PeriodicSyncWithJobDispatcher/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.05-Solution-ChargingBroadcastReceiver/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/src/main/res/layout/activity_main.xml
+++ b/Lesson10-Hydration-Reminder/T10.06-Solution-StickyBroadcastForCharging/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_main"
     android:layout_width="match_parent"
@@ -30,7 +31,7 @@
             android:onClick="incrementWater"
             android:padding="8dp"
             android:scaleType="fitCenter"
-            android:src="@drawable/ic_local_drink_grey_120px" />
+            app:srcCompat="@drawable/ic_local_drink_grey_120px" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -71,7 +72,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/charging_plug_content_desc"
-            android:src="@drawable/ic_power_grey_80px" />
+            app:srcCompat="@drawable/ic_power_grey_80px" />
 
         <TextView
             android:id="@+id/tv_charging_reminder_count"

--- a/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.01-Solution-ConstraintLayout/app/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {

--- a/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.02-Solution-DataBinding/app/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {

--- a/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/app/build.gradle
+++ b/Lesson11-Completeing-The-UI/T11.03-Solution-LandscapeLayout/app/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
 
     buildTypes {


### PR DESCRIPTION
Minimum SDK version is specified as 14 or less, but vector drawables
are not supported before Android 5.0 (Lollipop), SDK version 21.
Solutions should build without change.

Use the support library in solutions to prevent student confusion by
unnecessary error messages when they are upgrading to Gradle 4.1 and
Android Gradle plugin 3.0.1 as recommended by Android Studio 3.0.1.

See also:

https://developer.android.com/guide/topics/graphics/vector-drawable-resources.html
https://discussions.udacity.com/t/please-help-lesson-10-10-02-exercise-createnotification/542971/13?u=pointedears