### PR TITLE
changing complie to implementation

### DIFF
--- a/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/app/build.gradle
+++ b/Lesson01-Favorite-Toys/T01.01-Solution-CreateLayout/app/build.gradle
@@ -19,6 +19,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.1.0' //since compile is depreciated
 }


### PR DESCRIPTION
Since compile is depreciated. Android studio is  generating warnings to do so.