### PR TITLE
T05b.03 - move mGithubJson outside of AsyncTaskLoader

### DIFF
--- a/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/src/main/java/com/example/android/asynctaskloader/MainActivity.java
+++ b/Lesson05b-Smarter-GitHub-Repo-Search/T05b.03-Solution-PolishAsyncTask/app/src/main/java/com/example/android/asynctaskloader/MainActivity.java
@@ -161,13 +161,14 @@ public class MainActivity extends AppCompatActivity implements
         mErrorMessageDisplay.setVisibility(View.VISIBLE);
     }
 
+    // COMPLETED (1) Create a String member variable called mGithubJson that will store the raw JSON
+    /* This String will contain the raw JSON from the results of our Github search */
+    private String mGithubJson;
+        
     @Override
     public Loader<String> onCreateLoader(int id, final Bundle args) {
         return new AsyncTaskLoader<String>(this) {
 
-            // COMPLETED (1) Create a String member variable called mGithubJson that will store the raw JSON
-            /* This String will contain the raw JSON from the results of our Github search */
-            String mGithubJson;
 
             @Override
             protected void onStartLoading() {


### PR DESCRIPTION
When onCreateLoader call a new instance of AsyncTaskLoader will create and return, so mGithubJson always is null.
To mGithubJson hold json raw i moved to the MainActivity as a member class.
Now it's working as it should.