### PR TITLE
T07.01: added a default constructor

### DIFF
--- a/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/app/src/test/java/com/example/android/waitlist/ContractClassUnitTest.java
+++ b/Lesson07-Waitlist/T07.01-Exercise-CreateAContract/app/src/test/java/com/example/android/waitlist/ContractClassUnitTest.java
@@ -18,6 +18,9 @@ import static org.junit.Assert.assertTrue;
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
 public class ContractClassUnitTest {
+    
+    public ContractClassUnitTest(){
+    }
 
     @Test
     public void inner_class_exists() throws Exception {


### PR DESCRIPTION
Added a default parameterless constructor. Without the constructor the test suite doesn't runs.  Android Studio starts giving "Empty test suite" error. The same issue has been discussed [here](https://stackoverflow.com/q/14381694/465053)